### PR TITLE
Add support for loader chaining

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@
 	Author Brad Benvenuti @bradbenvenuti
 */
 module.exports = function(content) {
+	var regex = /(module\.exports\s?=\s?|exports\.default\s?=\s?|export default )"(.*)";?/;
+	var matches = content.match(regex);
+	content = (matches && matches[2]) ? matches[2] : content;
+	
 	this.cacheable && this.cacheable();
 	this.value = content;
 	return 'module.exports=function(scope){ return `' + content + '`};';


### PR DESCRIPTION
In order to chain this loader with another loader like [html-loader](http://github.com/webpack-contrib/html-loader), the export syntax needs to be removed. Should not break when used as only loader.

Test of regular expression can be found [here](https://regex101.com/r/hpG66t/1).